### PR TITLE
Mention "open"

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -40,7 +40,7 @@
             <div class="intro container">
                 <div class="intro-logo container"><img src="{{ site.baseurl }}/img/VespaIcon.png" class="img-responsive center-block"/></div>
                 <div class="intro-lead-in">Big data. Real time.</div>
-                <div class="intro-long">The big data serving engine - store, search, rank and organize big data in real time.</div>
+                <div class="intro-long">The Open Big Data Serving Engine - store, search, rank and organize big data in real time.</div>
                 <a href="http://docs.vespa.ai/documentation/vespa-quick-start.html" class="btn btn-xl intro-button">Get Started Now</a>
             </div>
         </div>


### PR DESCRIPTION
We don't say anywhere on this page that Vespa is open source.
I think yet another word in this sentence is too much, but that "open" is fine -
(cuz I like the phrase "the open big data serving engine").

Perhaps we should also say "open source" explicitly somewhere though?

@kkraune and @frodelu 