### PR TITLE
Change 'docs' to 'documentation'

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,7 +19,7 @@
                         <a href="#page-top"></a>
                     </li>
                     <li>
-                        <a href="http://docs.vespa.ai">Docs</a>
+                        <a href="http://docs.vespa.ai">Documentation</a>
                     </li>
                     <li>
                         <a href="https://github.com/vespa-engine">GitHub</a>


### PR DESCRIPTION
@frodelu please review

I think 'documentation' is clearer, and it doesn't seem we are out of space anywhere?
