### PR TITLE
uses 'sec' instead of 'second'

### DIFF
--- a/_includes/features.html
+++ b/_includes/features.html
@@ -64,7 +64,7 @@
                             <div class="feature-icon"><img src="{{ site.baseurl }}/img/features/flexible.svg"></div>
                             <div class="feature-text feature-title">Scalable and fast</div>
                             <div class="feature-text">
-                                Optimized for Thousands of queries/second, billions of documents.
+                                Optimized for Thousands of queries/sec, billions of documents.
                             </div>
                         </a>
                     </div>


### PR DESCRIPTION
@bratseth @frodelu, I hope this is still ok, we were getting three lines only on this feature. 