### PR TITLE
Remove double head section from template

### DIFF
--- a/_includes/htmlhead.html
+++ b/_includes/htmlhead.html
@@ -34,12 +34,6 @@
         <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
         <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
-</head>
-
-
-    <head>  
-
-
         <title>Vespa - Big Data. Real time.</title>
 
         <meta http-equiv="content-type" content="text/html; charset=utf-8">


### PR DESCRIPTION
__What?__
This change fixes an error where two head tags are present in the resulting html markup of the website. 

__How to test__
Check out this change and ensure the website renders correctly.