### PR TITLE
move logo from stylesheet

### DIFF
--- a/_includes/css/vespa.css
+++ b/_includes/css/vespa.css
@@ -70,18 +70,11 @@ section h3.section-subheading {
 }
 
 .navbar-default .navbar-brand {
-    background: transparent url({{ site.baseurl }}/img/Vespa-V2.png) no-repeat;
-    background-size: contain;
-    direction: ltr;
-    text-indent: -9000px;
-    height: 28px;
-    width: 100px;
-    display: inline-block;
-    font-family: {{ site.data.template.font.primary }};
-    font-weight: bold;
-    color: #{{ site.data.template.color.primary }};
-    margin-top: 16px;
-    margin-left: 10px;
+    float: left;
+    height: 60px;
+    padding: 16px 25px;
+    font-size: 18px;
+    line-height: 20px;
 }
 
 .navbar-default .nav li a {

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -9,7 +9,9 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand" href="#page-top">{{site.title}}</a>
+                <a class="navbar-brand" href="/">
+                    <img src="{{ site.baseurl }}/img/Vespa-V2.png" width="100" height="28">
+                </a>
             </div>
 
             <!-- Collect the nav links, forms, and other content for toggling -->


### PR DESCRIPTION
make it similar to the other sites 

the navbar is both in docs.css and vespa.css, which is one too many - with this, I can later include vespa.css on the cloud site and fix nav.html there, too 

bonus: site.baseurl does not resolve for some reason - workaround linking to /