### PR TITLE
how to find releases

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,6 +8,7 @@
                         <li><a href="https://docs.vespa.ai">Documentation</a>
                         <li><a href="https://github.com/vespa-engine/vespa">Open source</a>
                         <li><a href="/jobs">Jobs</a>
+                        <li><a href="/releases">Releases</a>
                     </ul>
                 </div>
                 <div class="col-xs-2 quicklink-section">

--- a/releases.html
+++ b/releases.html
@@ -1,0 +1,46 @@
+---
+title: Vespa Releases
+layout: page
+---
+
+<style>
+    .color-black {
+        color: #000000;
+    }
+
+    p, ul, li {
+        font-size: 16px;
+    }
+</style>
+
+<header id="releases" class="bg-light-blue">
+
+    <div class="intro container color-black">
+        <div class="row">
+            <div class="col-lg-12 text-center">
+                <div class="intro-lead-in ">Releases</div>
+            </div>
+            <div class="row">
+                <div class="col-lg-12 text-left feature-text ">
+                    <p>
+                        Vespa is released daily Mon-Thu, with some restrictions:
+                        <ul>
+                    <li>The release must pass all tests and run without regressions
+                        for select production applications</li>
+                    <li>The release is not manually blocked / holiday block window</li>
+                        </ul>
+                    </p>
+                    <p>
+                        Find releases at <a href="https://search.maven.org/artifact/com.yahoo.vespa/parent">com.yahoo.vespa:parent</a>.
+                        Vespa only releases from current major versjon.
+                    </p>
+                    <p>
+                        Vespa uses <a href="https://docs.vespa.ai/documentation/vespa-versions.html">semantic versioning</a>.
+                        It is normal to find "holes" in the version sequence, as releases are skipped.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</header>


### PR DESCRIPTION
I am sorry for very ugly web page. but this changes soon anyway, and I need to be able to refer to vespa.ai/releases from elsewhere
