### PR TITLE
Work-around for missing webrick

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,3 +36,5 @@ gem "wdm", "~> 0.1.0", :install_if => Gem.win_platform?
 # kramdown v1, comment out this line.
 gem "kramdown-parser-gfm"
 
+# Work-around for webrick no longer included in Ruby 3.0 (https://github.com/jekyll/jekyll/issues/8523)
+gem "webrick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,6 +256,7 @@ GEM
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     wdm (0.1.1)
+    webrick (1.7.0)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -269,6 +270,7 @@ DEPENDENCIES
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.0)
+  webrick
 
 BUNDLED WITH
-   2.1.4
+   2.2.3


### PR DESCRIPTION
@kkraune or @bratseth : It would no longer work to run the site locally using `bundle exec` due to the bug described in [jekyll/jekyll#8523](https://github.com/jekyll/jekyll/issues/8523). Adding `webrick` specifically to the Gemfile resolves this until proper fix is in.