### PR TITLE
Only to anchor fix for h1-h4 explicitly

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -232,7 +232,7 @@ button.section-searchbar {
 }
 
 /* Fix anchored links being hidden under navbar */
-*[id]:before {
+h1[id]::before, h2[id]::before, h3[id]::before, h4[id]::before {
     display: block;
     content: " ";
     margin-top: -75px;


### PR DESCRIPTION
@kkraune Please review. To my knowledge, we only use anchors for headers, so this will fix the mail form signup issue.