### PR TITLE
generate feed file for doc search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ _site/
 *~
 .idea/
 frontpage.iml
+vespa.ai_index.json
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,12 +15,7 @@ gem "minima", "~> 2.0"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
-gem "github-pages", group: :jekyll_plugins
-
-# If you have any plugins, put them here!
-group :jekyll_plugins do
-  gem "jekyll-feed", "~> 0.6"
-end
+gem "github-pages"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.

--- a/_config.yml
+++ b/_config.yml
@@ -46,3 +46,15 @@ plugins:
 exclude:
 - .idea
 
+search:
+  namespace: "vespa.ai"
+  endpoint : "https://vespa-documentation-search.vespa.global.vespa.oath.cloud"
+  do_feed  : true
+  do_index_removal_before_feed: false
+  feed_endpoints:
+    - url: https://vespacloud-docsearch.vespa-team.aws-us-east-1c.public.vespa.oath.cloud/
+      indexes:
+        - cloud_index.json
+    - url: https://vespacloud-docsearch.vespa-team.aws-ap-northeast-1a.public.vespa.oath.cloud/
+      indexes:
+        - frontpage_index.json

--- a/_config.yml
+++ b/_config.yml
@@ -54,7 +54,7 @@ search:
   feed_endpoints:
     - url: https://vespacloud-docsearch.vespa-team.aws-us-east-1c.public.vespa.oath.cloud/
       indexes:
-        - cloud_index.json
+        - vespa.ai_index.json
     - url: https://vespacloud-docsearch.vespa-team.aws-ap-northeast-1a.public.vespa.oath.cloud/
       indexes:
-        - frontpage_index.json
+        - vespa.ai_index.json

--- a/_plugins/vespa_index_generator.rb
+++ b/_plugins/vespa_index_generator.rb
@@ -1,0 +1,47 @@
+# Copyright Verizon Media. All rights reserved
+
+require 'json'
+require 'nokogiri'
+require 'kramdown/parser/kramdown'
+
+module Jekyll
+
+    class VespaIndexGenerator < Jekyll::Generator
+        priority :lowest
+
+        def generate(site)
+            namespace = site.config["search"]["namespace"]
+            operations = []
+            site.pages.each do |page|
+                if page.data["index"] == true
+                    operations.push({
+                        :fields => {
+                            :path => page.url,
+                            :namespace => namespace,
+                            :title => page.data["title"],
+                            :content => extract_text(page)
+                        }
+                    })
+                end
+            end
+
+            json = JSON.pretty_generate(operations)
+            File.open(namespace + "_index.json", "w") { |f| f.write(json) }
+        end
+
+        def extract_text(page)
+            ext = page.name[page.name.rindex('.')+1..-1]
+            if ext == "md"
+                input = Kramdown::Document.new(page.content).to_html
+            else
+                input = page.content
+            end
+            doc = Nokogiri::HTML(input)
+            doc.search('th,td').each{ |e| e.after "\n" }
+            content = doc.xpath("//text()").to_s
+            page_text = content.gsub("\r"," ").gsub("\n"," ")
+        end
+
+    end
+
+end

--- a/features.html
+++ b/features.html
@@ -2,6 +2,7 @@
 # Copyright Verizon Media. All rights reserved.
 title: "Vespa Features"
 layout: page
+index: true
 ---
 
 <!-- ToDo: move to common stylesheet once final -->

--- a/migrating-from-elastic-search-to-vespa.html
+++ b/migrating-from-elastic-search-to-vespa.html
@@ -2,6 +2,7 @@
 # Copyright Verizon Media. All rights reserved.
 title: Migrating from Elasticsearch
 layout: page
+index: true
 ---
 
 <div class="container-full">

--- a/usecases.html
+++ b/usecases.html
@@ -2,6 +2,7 @@
 # Copyright Verizon Media. All rights reserved.
 title: "Vespa Use Cases"
 layout: page
+index: true
 ---
 
 <!-- ToDo: move to common stylesheet once final -->

--- a/vespa-elastic-solr.html
+++ b/vespa-elastic-solr.html
@@ -2,6 +2,7 @@
 # Copyright Verizon Media. All rights reserved.
 title: Vespa and Elasticsearch / Solr (Lucene)
 layout: page
+index: true
 ---
 
 


### PR DESCRIPTION
there are a few articles we could include in search, whitelisted in this PR - it is possible to flip default to all, and explicitly blacklist those we will not include, easy to change later regardless

auto feeding is not set up yet, need changes in search result pages first for proper rendering of source (should we call these "vespa.ai"? the others are "documentation", "blog," ... ), will add after testing manually.

@bratseth @frodelu 