### PR TITLE
explicitly exclude directories/files

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,17 +34,15 @@ plugins:
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.
-# exclude:
-#   - Gemfile
-#   - Gemfile.lock
-#   - node_modules
-#   - vendor/bundle/
-#   - vendor/cache/
-#   - vendor/gems/
-#   - vendor/ruby/
-
 exclude:
-- .idea
+  - Gemfile
+  - Gemfile.lock
+  - node_modules
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
+  - .idea
 
 search:
   namespace: "vespaai"


### PR DESCRIPTION
error was `could not read file /home/runner/work/frontpage/frontpage/vendor/bundle/ruby/2.6.0/gems/jekyll-3.9.0/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb`

not sure why my local build is just fine -> explicitly exclude directories, so GH Action will not search these while building

@frodelu @bratseth 