### PR TITLE
no layout for 404

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,5 @@
 ---
 # Copyright Verizon Media. All rights reserved.
-layout: default
 title: Page not found
 ---
 


### PR DESCRIPTION
when building , we get this `Build Warning: Layout 'default' requested in 404.html does not exist.`

I think WEBrick is serving the 404 with style regardless of this, I could not figure it out completely, I think this will not change how it looks, we will see. the warning is gone

@frodelu @bratseth 