### PR TITLE
Move version details from Vespa doc

### DIFF
--- a/releases.html
+++ b/releases.html
@@ -2,6 +2,7 @@
 # Copyright Yahoo. All rights reserved.
 title: Releases
 layout: page
+index: true
 ---
 
 <div class="container-full">
@@ -9,14 +10,14 @@ layout: page
         <div class="xs-col-1-1 sm-col-1-1 md-col-1-1 lg-col-8-12 lg-col-off-2-12 xl-col-8-12 xl-col-off-2-12">
             <div class="flex-column">
                 <h1 id="releases">Releases</h1>
-
-                <p>Vespa is released every Monday through Thursday. Each public release has passed all our
+                <p>
+                    Vespa is released every Monday through Thursday. Each public release has passed all
                     functional and performance tests, and is already running the applications on our
                     public cloud service.
                 </p>
                 <br/>
                 <p>
-                    For each release of Vespa we provide the following artifacts:
+                    For each Vespa release, the following artifacts are provided:
                 </p>
                 <ul class="list">
                   <li><a href="https://search.maven.org/artifact/com.yahoo.vespa/parent">Java artifacts for building Vespa applications on Maven Central</a></li>
@@ -25,11 +26,51 @@ layout: page
                 </ul>
                 <br/>
                 <p>
+                    Releases:
+                </p>
+                <ul class="list">
+                    <li><a href="https://docs.vespa.ai/en/vespa7-release-notes.html">Vespa 7</a></li>
+                </ul>
+
+                <h2 id="versions">Versions</h2>
+                <p>
                     Vespa uses <a href="https://docs.vespa.ai/en/vespa-versions.html">semantic versioning</a>.
                     Each release is backwards compatible and supports live migration on running systems.
                     It is therefore a minor version number change. All new features are released on such minor versions.
                     Every second year or so we make a major version change which removes previously deprecated
                     functionality.
+                </p>
+                <p>
+                    Java APIs, web service APIs and all application package constructs are supported through a major release
+                    and only removed on a new release if they are already marked deprecated.
+                </p>
+                <p>
+                    Use of deprecated Java APIs will cause a warning on compilation,
+                    and use of deprecated application package constructs will cause a deprecation warning on deployment.
+                    Note that Java APIs come in two categories:
+                </p>
+                <ul class="list">
+                    <li><em>Public APIs</em> carry the compatibility guarantee and are visible from your code
+                        as well as in the javadoc</li> <!-- ToDo javadoc - link to something here if possible -->
+                    <li><em>Exported APIs</em> are also visible from your code,
+                        but is not in the public Javadoc and carry no compatibility guarantee</li>
+                </ul>
+                <p>
+                    Check the Javadoc list to verify that you are using public packages.
+                </p>
+                <p>
+                    In addition, some public Java classes and methods are marked with the com.yahoo.api.annotations.Beta tag.
+                    These are under development and may still change before they stabilize.
+                </p>
+
+
+
+                <h2 id="stored-data">Stored Data</h2>
+                <p>
+                    Data written to Vespa is compatible between adjacent releases.
+                    For self-hosted systems, it may be necessary to upgrade through each
+                    minor release rather than in larger leaps to ensure Vespa can read existing data.
+                    This is a good practice in any case.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
@bjormel : This is part of adding all files to the table of content in Vespa doc: I did not find a good place for it there, and I _think_ it is better to co-locate releases and version here, in one place - searchable anyway, so people will find it

FYI @bratseth 

Related: I also think the major release notes also is better on vespa.ai instead of docs.vespa.ai. The docs site is for the current major only, and more about how to use Vespa compared to how we build and release it. I have linked the vespa 7 notes for now, 8 will be linked when ready. Will move if you agree